### PR TITLE
feat: Require login for admin pages

### DIFF
--- a/app/controllers/admin/communities_controller.rb
+++ b/app/controllers/admin/communities_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::CommunitiesController < ApplicationController
+class Admin::CommunitiesController < AdminController
   def index
     @communities = Community.page(params[:page]).per(10)
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::UsersController < ApplicationController
+class Admin::UsersController < AdminController
   def index
     @users = User.page(params[:page]).per(10)
   end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AdminController < ApplicationController
+  before_action :require_login
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,4 +48,6 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  config.middleware.use Clearance::BackDoor
 end

--- a/test/controllers/admin/communities_controller_test.rb
+++ b/test/controllers/admin/communities_controller_test.rb
@@ -3,19 +3,31 @@
 require 'test_helper'
 
 class Admin::CommunitiesControllerTest < ActionDispatch::IntegrationTest
-  test 'should get index' do
+  test 'should redirect to sign in page when logged out' do
     get admin_communities_url
+    assert_redirected_to sign_in_path
+
+    get new_admin_community_url
+    assert_redirected_to sign_in_path
+
+    community = communities(:one)
+    get edit_admin_community_url(community)
+    assert_redirected_to sign_in_path
+  end
+
+  test 'should get index' do
+    get admin_communities_url(as: users(:member))
     assert_response :success
   end
 
   test 'should get new' do
-    get new_admin_community_url
+    get new_admin_community_url(as: users(:member))
     assert_response :success
   end
 
   test 'should get edit' do
     community = communities(:one)
-    get edit_admin_community_url(community)
+    get edit_admin_community_url(community, as: users(:member))
     assert_response :success
   end
 end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -3,8 +3,14 @@
 require 'test_helper'
 
 class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
-  test 'should get index' do
+  test 'should redirect to sign in page when logged out' do
     get admin_users_url
+    assert_redirected_to sign_in_path
+  end
+
+  test 'should get index when logged in' do
+    user = users(:member)
+    get admin_users_url(as: user)
     assert_response :success
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,5 @@
+member:
+  name: John Doe
+  email: john.doe@example.com
+  encrypted_password: <%= BCrypt::Password.create('password123', cost: 4) %>
+  remember_token: <%= Clearance::Token.new %>


### PR DESCRIPTION
This is an intermediate feature to require a logged in user to access admin pages. In a future change, the User role must be `admin` to perform each admin action.

In addition to requiring login, the change also adds the following:

* A new `AdminController` that's now the parent class of admin controllers
* For testing, we use the `Clearance::Backdoor` middleware to avoid the manual steps of logging in
* A new fixture, `users.yml`
