### PR TITLE
feat: Require admin for user administration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'jbuilder', '~> 2.7'
 gem 'haml-rails', '~> 2.0'
 gem 'clearance'
 gem 'kaminari'
+gem 'pundit'
 
 gem 'bootsnap', '>= 1.4.2', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,8 @@ GEM
       pry (>= 0.10.4)
     public_suffix (4.0.1)
     puma (3.12.1)
+    pundit (2.1.0)
+      activesupport (>= 3.0.0)
     rack (2.0.7)
     rack-proxy (0.6.5)
       rack
@@ -267,6 +269,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry-rails
   puma (~> 3.11)
+  pundit
   rails (~> 6.0.0)
   sass-rails (~> 5)
   selenium-webdriver

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,11 +2,13 @@
 
 class Admin::UsersController < AdminController
   def index
+    authorize User
     @users = User.page(params[:page]).per(10)
   end
 
   def destroy
     @user = User.find(params[:id])
+    authorize @user
     @user.destroy
 
     redirect_to admin_users_path

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,6 @@
 
 class ApplicationController < ActionController::Base
   include Clearance::Controller
+  alias clearance_authorize authorize
+  include Pundit
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UserPolicy < ApplicationPolicy
+  def index?
+    user.admin?
+  end
+
+  def destroy?
+    user.admin?
+  end
+end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -8,8 +8,15 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to sign_in_path
   end
 
-  test 'should get index when logged in' do
+  test 'should not get index when logged in as member' do
     user = users(:member)
+    assert_raises(Pundit::NotAuthorizedError) do
+      get admin_users_url(as: user)
+    end
+  end
+
+  test 'should get index when logged in as admin' do
+    user = users(:admin)
     get admin_users_url(as: user)
     assert_response :success
   end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     name { Faker::Name.name }
     email { Faker::Internet.unique.email }
     password { 'password123' }
+    password_confirmation { 'password123' }
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,3 +3,10 @@ member:
   email: john.doe@example.com
   encrypted_password: <%= BCrypt::Password.create('password123', cost: 4) %>
   remember_token: <%= Clearance::Token.new %>
+
+admin:
+  name: Admin
+  email: admin@example.com
+  encrypted_password: <%= BCrypt::Password.create('password123', cost: 4) %>
+  remember_token: <%= Clearance::Token.new %>
+  role: admin

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UserPolicyTest < ActiveSupport::TestCase
+  def setup
+    @member = users(:member)
+    @admin = users(:admin)
+  end
+
+  def policy(user, record)
+    Pundit.policy!(user, record)
+  end
+
+  test 'index' do
+    refute policy(@member, User).index?
+    assert policy(@admin, User).index?
+  end
+
+  test 'destroy' do
+    user = create(:user)
+    refute policy(@member, user).destroy?
+    assert policy(@admin, user).destroy?
+  end
+end


### PR DESCRIPTION
This change adds the Pundit library for simple authorization. It creates a policy to only allow admin users to perform the actions in `Admin::UsersController`.

**Note:** There's a conflict when including `Clearance::Controller` and `Pundit` in the `ApplicationController` as both implement an `authorize` method. We handle this conflict by aliasing the deprecated `authorize` method of Clearance.
