### PR TITLE
chore: Bump minimist from 1.2.0 to 1.2.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4394,9 +4394,9 @@ minimist@0.0.8:
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
 minimist@^1.1.3, minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Bump `minimist` from 1.2.0 to 1.2.5. This addresses CVE-2020-7598.

To patch `minimist` package, temporarily add the following `minimist` dependencies in package.json one at a time:

```json
"minimist": "^1.1.3"
"minimist": "^1.2.0"
```

Each time, run:

```bash
$ yarn upgrade minimist
```

Then remove `minimist` from package.json.
